### PR TITLE
feat: add packageLicenseOverride

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -47,7 +47,7 @@ jobs:
         run: dart test --coverage=./coverage
 
       - name: Collect coverage
-        run: format_coverage --check-ignore --packages=.packages --report-on=lib --lcov -o ./coverage/lcov.info -i ./coverage
+        run: format_coverage --check-ignore --package=. --report-on=lib --lcov -o ./coverage/lcov.info -i ./coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -16,11 +16,15 @@ class Config {
   /// Map to override copyright notices for packages, if they are not parsed correctly.
   final Map<String, String> copyrightNotice;
 
+  /// Map to override licenses for packages, if they are not parsed correctly.
+  final Map<String, String> packageLicenseOverride;
+
   Config._({
     required this.permittedLicenses,
     required this.rejectedLicenses,
     required this.approvedPackages,
     required this.copyrightNotice,
+    required this.packageLicenseOverride,
   });
 
   /// Parses and creates config from a file
@@ -37,6 +41,7 @@ class Config {
     Object? rejectedLicenses = config['rejectedLicenses'];
     Object? approvedPackages = config['approvedPackages'];
     Object? copyrightNotice = config['copyrightNotice'];
+    Object? packageLicenseOverride = config['packageLicenseOverride'];
     if (permittedLicenses == null) {
       return throw FormatException('`permittedLicenses` not defined');
     }
@@ -83,35 +88,46 @@ class Config {
         checkedApprovedPackages[license] = stringApprovedPackages;
       }
     }
-    Map<String, String> checkedCopyrightNotice = {};
-    if (copyrightNotice != null) {
-      if (copyrightNotice is! Map) {
-        return throw FormatException('`copyrightNotice` not defined as a map');
-      }
-      for (MapEntry<dynamic, dynamic> entry in copyrightNotice.entries) {
-        Object packageName = entry.key;
-        Object copyright = entry.value;
+    Map<String, String> checkedCopyrightNotice =
+        _checkStringMap(copyrightNotice, 'copyrightNotice');
 
-        if (packageName is! String) {
-          return throw FormatException(
-            '`copyrightNotice` must be keyed by a string package name',
-          );
-        }
-
-        if (copyright is! String) {
-          return throw FormatException(
-            '`copyrightNotice` value must bea string copyright notice',
-          );
-        }
-        checkedCopyrightNotice[packageName] = copyright;
-      }
-    }
+    Map<String, String> checkedPackageLicenseOverride =
+        _checkStringMap(packageLicenseOverride, 'packageLicenseOverride');
 
     return Config._(
       permittedLicenses: stringLicenses,
       approvedPackages: checkedApprovedPackages,
       rejectedLicenses: stringRejectLicenses,
       copyrightNotice: checkedCopyrightNotice,
+      packageLicenseOverride: checkedPackageLicenseOverride,
     );
   }
+}
+
+Map<String, String> _checkStringMap(Object? map, String variableName) {
+  Map<String, String> checkedMap = {};
+  if (map != null) {
+    if (map is! Map) {
+      return throw FormatException('`$variableName` not defined as a map');
+    }
+    for (MapEntry<dynamic, dynamic> entry in map.entries) {
+      Object mapKey = entry.key;
+      Object mapValue = entry.value;
+
+      if (mapKey is! String) {
+        return throw FormatException(
+          '`$variableName` must be keyed by a string',
+        );
+      }
+
+      if (mapValue is! String) {
+        return throw FormatException(
+          '`$variableName` value must be a string',
+        );
+      }
+      checkedMap[mapKey] = mapValue;
+    }
+  }
+
+  return checkedMap;
 }

--- a/lib/src/generate_disclaimer.dart
+++ b/lib/src/generate_disclaimer.dart
@@ -76,18 +76,20 @@ Future<DisclaimerDisplay<C, F>> generatePackageDisclaimer<C, F>({
 }) async {
   String copyright =
       config.copyrightNotice[package.name] ?? await package.copyright;
+  String licenseName =
+      config.packageLicenseOverride[package.name] ?? await package.licenseName;
 
   return DisclaimerDisplay(
     cli: disclaimerCLIDisplay(
       packageName: package.name,
       copyright: copyright,
-      licenseName: await package.licenseName,
+      licenseName: licenseName,
       sourceLocation: package.sourceLocation,
     ),
     file: disclaimerFileDisplay(
       packageName: package.name,
       copyright: copyright,
-      licenseName: await package.licenseName,
+      licenseName: licenseName,
       sourceLocation: package.sourceLocation,
       licenseFile: package.licenseFile,
     ),

--- a/test/lib/src/config_test.dart
+++ b/test/lib/src/config_test.dart
@@ -163,15 +163,32 @@ void main() {
         testDescription:
             'throw format exception when copyright notice is not defined with string keys',
         fileName: 'invalid_copyright_string_key_config',
-        expectedErrorMessage:
-            '`copyrightNotice` must be keyed by a string package name',
+        expectedErrorMessage: '`copyrightNotice` must be keyed by a string',
       ),
       _ConfigErrorTest(
         testDescription:
             'throw format exception when copyright notice is not defined with string values',
         fileName: 'invalid_copyright_string_value_config',
+        expectedErrorMessage: '`copyrightNotice` value must be a string',
+      ),
+      _ConfigErrorTest(
+        testDescription:
+            'throw format exception when package license override is not defined as a map',
+        fileName: 'invalid_license_override_list_config',
+        expectedErrorMessage: '`packageLicenseOverride` not defined as a map',
+      ),
+      _ConfigErrorTest(
+        testDescription:
+            'throw format exception when package license override is not defined with string keys',
+        fileName: 'invalid_license_override_string_key_config',
         expectedErrorMessage:
-            '`copyrightNotice` value must bea string copyright notice',
+            '`packageLicenseOverride` must be keyed by a string',
+      ),
+      _ConfigErrorTest(
+        testDescription:
+            'throw format exception when package license override is not defined with string values',
+        fileName: 'invalid_license_override_string_value_config',
+        expectedErrorMessage: '`packageLicenseOverride` value must be a string',
       ),
     ];
 

--- a/test/lib/src/fixtures/invalid_license_override_list_config.yaml
+++ b/test/lib/src/fixtures/invalid_license_override_list_config.yaml
@@ -1,0 +1,12 @@
+permittedLicenses:
+  - Apache-2.0
+
+rejectedLicenses:
+  - MIT
+
+approvedPackages:
+  GPL-1.0:
+    - mlb
+
+packageLicenseOverride:
+  - mlb

--- a/test/lib/src/fixtures/invalid_license_override_string_key_config.yaml
+++ b/test/lib/src/fixtures/invalid_license_override_string_key_config.yaml
@@ -1,0 +1,12 @@
+permittedLicenses:
+  - Apache-2.0
+
+rejectedLicenses:
+  - MIT
+
+approvedPackages:
+  GPL-1.0:
+    - mlb
+
+packageLicenseOverride:
+  1: "baseball"

--- a/test/lib/src/fixtures/invalid_license_override_string_value_config.yaml
+++ b/test/lib/src/fixtures/invalid_license_override_string_value_config.yaml
@@ -1,0 +1,12 @@
+permittedLicenses:
+  - Apache-2.0
+
+rejectedLicenses:
+  - MIT
+
+approvedPackages:
+  GPL-1.0:
+    - mlb
+
+packageLicenseOverride:
+  mlb: true

--- a/test/lib/src/fixtures/valid_config_license_override.yaml
+++ b/test/lib/src/fixtures/valid_config_license_override.yaml
@@ -1,0 +1,13 @@
+permittedLicenses:
+  - Apache-2.0
+  - BSD-3-Clause
+
+rejectedLicenses:
+  - MIT
+
+approvedPackages:
+  GPL-1.0:
+    - mlb
+
+packageLicenseOverride:
+  dodgers: BSD-3-Clause

--- a/test/lib/src/generate_disclaimer_test.dart
+++ b/test/lib/src/generate_disclaimer_test.dart
@@ -99,6 +99,31 @@ void main() {
       );
     });
 
+    test('should generate the disclaimer with package license overrides',
+        () async {
+      Config config = Config.fromFile(
+        File('test/lib/src/fixtures/valid_config_license_override.yaml'),
+      );
+      DisclaimerDisplay<String, String> result =
+          await generatePackageDisclaimer<String, String>(
+        config: config,
+        package: MockedDependencyChecker.withLicenseFile(
+          'dodgers',
+          LicenseStatus.approved,
+          File('/dodger/stadium'),
+        ),
+        disclaimerCLIDisplay: disclaimerCLIDisplay,
+        disclaimerFileDisplay: disclaimerFileDisplay,
+      );
+
+      expect(result.cli,
+          'cli: dodgers BSD-3-Clause 1958 Los Angeles Chavez Ravine');
+      expect(
+        result.file,
+        'file: dodgers BSD-3-Clause 1958 Los Angeles Chavez Ravine /dodger/stadium',
+      );
+    });
+
     test(
         'should generate the disclaimer for a single package overriding the copyright with what is defined in the config',
         () async {

--- a/test/lib/src/generate_disclaimer_test.dart
+++ b/test/lib/src/generate_disclaimer_test.dart
@@ -116,8 +116,10 @@ void main() {
         disclaimerFileDisplay: disclaimerFileDisplay,
       );
 
-      expect(result.cli,
-          'cli: dodgers BSD-3-Clause 1958 Los Angeles Chavez Ravine');
+      expect(
+        result.cli,
+        'cli: dodgers BSD-3-Clause 1958 Los Angeles Chavez Ravine',
+      );
       expect(
         result.file,
         'file: dodgers BSD-3-Clause 1958 Los Angeles Chavez Ravine /dodger/stadium',


### PR DESCRIPTION
packageLicenseOverride allows for the overriding of the license text
generated by generate-disclaimer. This is especially useful for when
the license is not properly detected.

Fix github action to use new format_coverage option.