### PR TITLE
feat: add source location override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ doc/api/
 
 # Editor files
 .vscode
-
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -25,8 +25,19 @@ rejectedLicenses:
 
 copyrightNotice:
   mlb: "2000 MLB."
+
+packageLicenseOverride:
+  dodgers: BSD-3-Clause
+
+packageSourceOverride:
+  dodgers: https://dodgers.com
+
+omitDisclaimer:
+  - angles
 ```
 
 This file can be referenced when calling `lic_ck check-licenses` with the `--config` option.
 
 `lic_ck` or `lic_ck -h` will display help
+
+For more details on the YAML config options see the [Config documentation](https://pub.dev/documentation/license_checker/latest/generate_disclaimer/Config-class.html)

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -19,6 +19,10 @@ class Config {
   /// [Map] to override licenses for packages, if they are not parsed correctly.
   final Map<String, String> packageLicenseOverride;
 
+  /// [Map] to override the source location for packages, if they are not parsed correctly
+  /// or present in the pubspec.yaml.
+  final Map<String, String> packageSourceOverride;
+
   /// [List] of packages who's license and copyright notice should not be added to the discalimer
   final List<String> omitDisclaimer;
 
@@ -28,6 +32,7 @@ class Config {
     required this.approvedPackages,
     required this.copyrightNotice,
     required this.packageLicenseOverride,
+    required this.packageSourceOverride,
     required this.omitDisclaimer,
   });
 
@@ -46,6 +51,7 @@ class Config {
     Object? approvedPackages = config['approvedPackages'];
     Object? copyrightNotice = config['copyrightNotice'];
     Object? packageLicenseOverride = config['packageLicenseOverride'];
+    Object? packageSourceOverride = config['packageSourceOverride'];
     Object? omitDisclaimer = config['omitDisclaimer'];
     if (permittedLicenses == null) {
       return throw FormatException('`permittedLicenses` not defined');
@@ -108,12 +114,16 @@ class Config {
     Map<String, String> checkedPackageLicenseOverride =
         _checkStringMap(packageLicenseOverride, 'packageLicenseOverride');
 
+    Map<String, String> checkedPackageSourceOverride =
+        _checkStringMap(packageSourceOverride, 'packageSourceOverride');
+
     return Config._(
       permittedLicenses: stringLicenses,
       approvedPackages: checkedApprovedPackages,
       rejectedLicenses: stringRejectLicenses,
       copyrightNotice: checkedCopyrightNotice,
       packageLicenseOverride: checkedPackageLicenseOverride,
+      packageSourceOverride: checkedPackageSourceOverride,
       omitDisclaimer: stringOmitDisclaimer,
     );
   }

--- a/lib/src/generate_disclaimer.dart
+++ b/lib/src/generate_disclaimer.dart
@@ -79,19 +79,21 @@ Future<DisclaimerDisplay<C, F>> generatePackageDisclaimer<C, F>({
       config.copyrightNotice[package.name] ?? await package.copyright;
   String licenseName =
       config.packageLicenseOverride[package.name] ?? await package.licenseName;
+  String sourceLocation =
+      config.packageSourceOverride[package.name] ?? package.sourceLocation;
 
   return DisclaimerDisplay(
     cli: disclaimerCLIDisplay(
       packageName: package.name,
       copyright: copyright,
       licenseName: licenseName,
-      sourceLocation: package.sourceLocation,
+      sourceLocation: sourceLocation,
     ),
     file: disclaimerFileDisplay(
       packageName: package.name,
       copyright: copyright,
       licenseName: licenseName,
-      sourceLocation: package.sourceLocation,
+      sourceLocation: sourceLocation,
       licenseFile: package.licenseFile,
     ),
   );

--- a/test/lib/src/config_test.dart
+++ b/test/lib/src/config_test.dart
@@ -25,6 +25,7 @@ class _ConfigSuccessTest {
   final Map<String, String> expectedCopyrightNotice;
   final List<String> expectedOmitDisclaimer;
   final Map<String, String> expectedPackageLicenseOverride;
+  final Map<String, String> expectedPackageSourceOverride;
 
   _ConfigSuccessTest({
     required this.fileName,
@@ -35,6 +36,7 @@ class _ConfigSuccessTest {
     required this.testDescription,
     required this.expectedOmitDisclaimer,
     required this.expectedPackageLicenseOverride,
+    required this.expectedPackageSourceOverride,
   });
 }
 
@@ -64,6 +66,7 @@ void main() {
         expectedCopyrightNotice: {},
         expectedOmitDisclaimer: [],
         expectedPackageLicenseOverride: {},
+        expectedPackageSourceOverride: {},
       ),
       _ConfigSuccessTest(
         testDescription: 'Parse valid config with everything defined',
@@ -73,9 +76,10 @@ void main() {
         expectedApprovedPackages: {
           'GPL-1.0': ['mlb'],
         },
-        expectedCopyrightNotice: {},
+        expectedCopyrightNotice: {'mlb': '2000 MLB.'},
         expectedOmitDisclaimer: ['angles'],
         expectedPackageLicenseOverride: {'dodgers': 'BSD-3-Clause'},
+        expectedPackageSourceOverride: {'dodgers': 'https://dodgers.com'},
       ),
       _ConfigSuccessTest(
         testDescription: 'Parse valid config with no rejected licenses',
@@ -88,6 +92,7 @@ void main() {
         expectedCopyrightNotice: {},
         expectedOmitDisclaimer: [],
         expectedPackageLicenseOverride: {},
+        expectedPackageSourceOverride: {},
       ),
       _ConfigSuccessTest(
         testDescription: 'Parse valid config and ignore non string licenses',
@@ -100,6 +105,7 @@ void main() {
         expectedCopyrightNotice: {},
         expectedOmitDisclaimer: [],
         expectedPackageLicenseOverride: {},
+        expectedPackageSourceOverride: {},
       ),
       _ConfigSuccessTest(
         testDescription: 'Parse valid config with copyright notice overrides',
@@ -112,6 +118,33 @@ void main() {
         expectedCopyrightNotice: {'mlb': '2000 MLB.'},
         expectedOmitDisclaimer: [],
         expectedPackageLicenseOverride: {},
+        expectedPackageSourceOverride: {},
+      ),
+      _ConfigSuccessTest(
+        testDescription: 'Parse valid config with license overrides',
+        fileName: 'valid_config_license_override',
+        expectedPermittedLicenses: ['Apache-2.0', 'BSD-3-Clause'],
+        expectedRejectedLicenses: ['MIT'],
+        expectedApprovedPackages: {
+          'GPL-1.0': ['mlb'],
+        },
+        expectedCopyrightNotice: {},
+        expectedOmitDisclaimer: [],
+        expectedPackageLicenseOverride: {'dodgers': 'BSD-3-Clause'},
+        expectedPackageSourceOverride: {},
+      ),
+      _ConfigSuccessTest(
+        testDescription: 'Parse valid config with source overrides',
+        fileName: 'valid_config_source_override',
+        expectedPermittedLicenses: ['Apache-2.0', 'BSD-3-Clause'],
+        expectedRejectedLicenses: ['MIT'],
+        expectedApprovedPackages: {
+          'GPL-1.0': ['mlb'],
+        },
+        expectedCopyrightNotice: {},
+        expectedOmitDisclaimer: [],
+        expectedPackageLicenseOverride: {},
+        expectedPackageSourceOverride: {'dodgers': 'https://dodgers.com'},
       ),
     ];
     for (_ConfigSuccessTest t in configSuccessTests) {
@@ -127,6 +160,10 @@ void main() {
         expect(
           validConfig.packageLicenseOverride,
           t.expectedPackageLicenseOverride,
+        );
+        expect(
+          validConfig.packageSourceOverride,
+          t.expectedPackageSourceOverride,
         );
       });
     }
@@ -208,6 +245,25 @@ void main() {
             'throw format exception when package license override is not defined with string values',
         fileName: 'invalid_license_override_string_value_config',
         expectedErrorMessage: '`packageLicenseOverride` value must be a string',
+      ),
+      _ConfigErrorTest(
+        testDescription:
+            'throw format exception when package source override is not defined as a map',
+        fileName: 'invalid_source_override_list_config',
+        expectedErrorMessage: '`packageSourceOverride` not defined as a map',
+      ),
+      _ConfigErrorTest(
+        testDescription:
+            'throw format exception when package source override is not defined with string keys',
+        fileName: 'invalid_source_override_string_key_config',
+        expectedErrorMessage:
+            '`packageSourceOverride` must be keyed by a string',
+      ),
+      _ConfigErrorTest(
+        testDescription:
+            'throw format exception when package source override is not defined with string values',
+        fileName: 'invalid_source_override_string_value_config',
+        expectedErrorMessage: '`packageSourceOverride` value must be a string',
       ),
       _ConfigErrorTest(
         testDescription:

--- a/test/lib/src/fixtures/invalid_source_override_list_config.yaml
+++ b/test/lib/src/fixtures/invalid_source_override_list_config.yaml
@@ -1,0 +1,12 @@
+permittedLicenses:
+  - Apache-2.0
+
+rejectedLicenses:
+  - MIT
+
+approvedPackages:
+  GPL-1.0:
+    - mlb
+
+packageSourceOverride:
+  - mlb

--- a/test/lib/src/fixtures/invalid_source_override_string_key_config.yaml
+++ b/test/lib/src/fixtures/invalid_source_override_string_key_config.yaml
@@ -1,0 +1,12 @@
+permittedLicenses:
+  - Apache-2.0
+
+rejectedLicenses:
+  - MIT
+
+approvedPackages:
+  GPL-1.0:
+    - mlb
+
+packageSourceOverride:
+  1: "baseball"

--- a/test/lib/src/fixtures/invalid_source_override_string_value_config.yaml
+++ b/test/lib/src/fixtures/invalid_source_override_string_value_config.yaml
@@ -1,0 +1,12 @@
+permittedLicenses:
+  - Apache-2.0
+
+rejectedLicenses:
+  - MIT
+
+approvedPackages:
+  GPL-1.0:
+    - mlb
+
+packageSourceOverride:
+  mlb: true

--- a/test/lib/src/fixtures/valid_config_source_override.yaml
+++ b/test/lib/src/fixtures/valid_config_source_override.yaml
@@ -1,5 +1,6 @@
 permittedLicenses:
   - Apache-2.0
+  - BSD-3-Clause
 
 rejectedLicenses:
   - MIT
@@ -7,15 +8,6 @@ rejectedLicenses:
 approvedPackages:
   GPL-1.0:
     - mlb
-
-omitDisclaimer:
-  - angles
-
-copyrightNotice:
-  mlb: "2000 MLB."
-
-packageLicenseOverride:
-  dodgers: BSD-3-Clause
 
 packageSourceOverride:
   dodgers: https://dodgers.com

--- a/test/lib/src/generate_disclaimer_test.dart
+++ b/test/lib/src/generate_disclaimer_test.dart
@@ -126,6 +126,33 @@ void main() {
       );
     });
 
+    test('should generate the disclaimer with package source overrides',
+        () async {
+      Config config = Config.fromFile(
+        File('test/lib/src/fixtures/valid_config_source_override.yaml'),
+      );
+      DisclaimerDisplay<String, String> result =
+          await generatePackageDisclaimer<String, String>(
+        config: config,
+        package: MockedDependencyChecker.withLicenseFile(
+          'dodgers',
+          LicenseStatus.approved,
+          File('/dodger/stadium'),
+        ),
+        disclaimerCLIDisplay: disclaimerCLIDisplay,
+        disclaimerFileDisplay: disclaimerFileDisplay,
+      );
+
+      expect(
+        result.cli,
+        'cli: dodgers swag 1958 Los Angeles https://dodgers.com',
+      );
+      expect(
+        result.file,
+        'file: dodgers swag 1958 Los Angeles https://dodgers.com /dodger/stadium',
+      );
+    });
+
     test(
         'should generate the disclaimer for a single package overriding the copyright with what is defined in the config',
         () async {


### PR DESCRIPTION
The packageSourceOverride YAML option allows users to override or
define the location of the source code of a package in the event that
one cannot be found.