### PR TITLE
feat: add noDevDependencies flag

### DIFF
--- a/lib/src/commands/generate_disclaimer.dart
+++ b/lib/src/commands/generate_disclaimer.dart
@@ -30,6 +30,12 @@ class GenerateDisclaimer extends Command<int> {
         negatable: false,
         help: 'Write the disclaimers to the file without prompting.',
       )
+      ..addFlag(
+        'noDev',
+        abbr: 'n',
+        help: 'Do not include dev dependencies in the disclaimer.',
+        negatable: false,
+      )
       ..addOption(
         'file',
         abbr: 'f',
@@ -48,6 +54,7 @@ class GenerateDisclaimer extends Command<int> {
   Future<int> run() async {
     String disclaimerName = argResults?['file'];
     String outputPath = argResults?['path'];
+    bool noDevDependencies = argResults?['noDev'];
     bool skipPrompts = argResults?['yes'];
     bool showDirectDepsOnly = globalResults?['direct'];
     String configPath = globalResults?['config'];
@@ -69,6 +76,7 @@ class GenerateDisclaimer extends Command<int> {
       config: config,
       packageConfig: packageConfig,
       showDirectDepsOnly: showDirectDepsOnly,
+      noDevDependencies: noDevDependencies,
       disclaimerCLIDisplay: formatDisclaimerRow,
       disclaimerFileDisplay: formatDisclaimer,
     );

--- a/lib/src/generate_disclaimer.dart
+++ b/lib/src/generate_disclaimer.dart
@@ -40,6 +40,7 @@ Future<DisclaimerDisplay<List<C>, List<F>>> generateDisclaimers<C, F>({
   required Config config,
   required PackageChecker packageConfig,
   required bool showDirectDepsOnly,
+  required bool noDevDependencies,
   required DisclaimerCLIDisplayFunction<C> disclaimerCLIDisplay,
   required DisclaimerFileDisplayFunction<F> disclaimerFileDisplay,
 }) async {
@@ -52,6 +53,11 @@ Future<DisclaimerDisplay<List<C>, List<F>>> generateDisclaimers<C, F>({
         config.omitDisclaimer.contains(package.name)) {
       // Ignore dependencies not defined in the packages pubspec.yaml
       // Do not generate disclaimer for ignored packages
+      continue;
+    }
+    if (noDevDependencies &&
+        packageConfig.pubspec.devDependencies.containsKey(package.name)) {
+      // Ignore dev dependencies
       continue;
     }
     DisclaimerDisplay<C, F>? packageDisclaimer =


### PR DESCRIPTION
The `noDevDependencies` flag allows to restrict the disclaimer
generation to only dependencies included in the production bundle.