### PR TITLE
Use `packageLicenseOverride` for `check-licenses`.

### DIFF
--- a/lib/src/dependency_checker.dart
+++ b/lib/src/dependency_checker.dart
@@ -138,6 +138,11 @@ class DependencyChecker {
 
   /// The license name associated with the package
   Future<String> get licenseName async {
+    String? overriddenLicense = config.packageLicenseOverride[name];
+    if (overriddenLicense != null) {
+      return overriddenLicense;
+    }
+
     if (licenseFile == null) {
       return noFileLicense;
     }

--- a/test/lib/src/config_test.dart
+++ b/test/lib/src/config_test.dart
@@ -123,7 +123,7 @@ void main() {
       _ConfigSuccessTest(
         testDescription: 'Parse valid config with license overrides',
         fileName: 'valid_config_license_override',
-        expectedPermittedLicenses: ['Apache-2.0', 'BSD-3-Clause'],
+        expectedPermittedLicenses: ['BSD-3-Clause'],
         expectedRejectedLicenses: ['MIT'],
         expectedApprovedPackages: {
           'GPL-1.0': ['mlb'],

--- a/test/lib/src/dependency_checker_test.dart
+++ b/test/lib/src/dependency_checker_test.dart
@@ -89,6 +89,45 @@ void main() {
       });
     }
   });
+  group('license override', () {
+    Config config = Config.fromFile(
+      File('test/lib/src/fixtures/valid_config_license_override.yaml'),
+    );
+    DependencyChecker dc = DependencyChecker(
+      config: config,
+      package: Package(
+        'dodgers',
+        Uri(
+          scheme: 'file',
+          path: Directory.current.absolute.path +
+              '/test/lib/src/fixtures/dodgers/',
+        ),
+      ),
+    );
+
+    List<DependencyTest<Object?>> _validTests = [
+      DependencyTest<Object?>(
+        testProperty: (d) async {
+          return d.licenseName;
+        },
+        expectedReturnMatcher: () => 'BSD-3-Clause',
+        testDescription: 'should get the license name',
+      ),
+      DependencyTest<Object?>(
+        testProperty: (d) async {
+          return d.packageLicenseStatus;
+        },
+        expectedReturnMatcher: () => LicenseStatus.permitted,
+        testDescription: 'should get the license status based on the config',
+      ),
+    ];
+
+    for (DependencyTest<Object?> t in _validTests) {
+      test(t.testDescription, () async {
+        expect(await t.testProperty(dc), t.expectedReturnMatcher());
+      });
+    }
+  });
 
   group('No license file', () {
     Config config =

--- a/test/lib/src/dependency_checker_test.dart
+++ b/test/lib/src/dependency_checker_test.dart
@@ -57,14 +57,14 @@ void main() {
         testProperty: (d) async {
           return d.licenseName;
         },
-        expectedReturnMatcher: () => 'Apache-2.0',
+        expectedReturnMatcher: () => 'BSD-3-Clause',
         testDescription: 'should get the license name',
       ),
       DependencyTest<Object?>(
         testProperty: (d) async {
           return d.packageLicenseStatus;
         },
-        expectedReturnMatcher: () => LicenseStatus.permitted,
+        expectedReturnMatcher: () => LicenseStatus.needsApproval,
         testDescription: 'should get the license status based on the config',
       ),
       DependencyTest<Object?>(

--- a/test/lib/src/fixtures/valid_config_license_override.yaml
+++ b/test/lib/src/fixtures/valid_config_license_override.yaml
@@ -1,5 +1,4 @@
 permittedLicenses:
-  - Apache-2.0
   - BSD-3-Clause
 
 rejectedLicenses:


### PR DESCRIPTION
The `lic_ck check-licenses` command will now use the `packageLicenseOverride`.

Fixes #35